### PR TITLE
Set large stack size for fibers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ or input `ctrl+c` or `ctrl+d` to stop D-Prolog.
 
 - `example/family.pro`
 - `example/list.pro`
+- `example/factorial.pro`
 
 ### Options
 

--- a/example/factorial.pro
+++ b/example/factorial.pro
@@ -1,0 +1,10 @@
+
+% Result is the factorial of N.
+factorial(N, Result) :- factorial2(N, 1, Result).
+
+factorial2(0, Result, Result).
+factorial2(N, Acc, Result) :-
+    N > 0,
+    Acc1 is N * Acc,
+    N1 is N - 1,
+    factorial2(N1, Acc1, Result).

--- a/src/dprolog/engine/Executor.d
+++ b/src/dprolog/engine/Executor.d
@@ -114,7 +114,8 @@ private:
     Variant first, second;
     UnificationUF unionFind = buildUnionFind(query, first, second);
     auto result = new Generator!UnificationUF(
-      () => unificate(first, unionFind)
+      () => unificate(first, unionFind),
+      1<<20
     );
     if (query.first.isDetermined) {
       _engine.writelnMessage(DefaultMessage((!result.empty).to!string ~ "."));
@@ -186,7 +187,8 @@ private:
     if (term.token == Operator.comma) {
       // conjunction
       new Generator!UnificationUF(
-        () => unificate(variant.children.front, unionFind)
+        () => unificate(variant.children.front, unionFind),
+        1<<20
       ).array.each!(
         uf => unificate(variant.children.back, uf)
       );


### PR DESCRIPTION
- Set large stack size for fibers.
    - Fix https://github.com/ArkArk/d-prolog/issues/46
- Add `example/factorial.pro`